### PR TITLE
hotfix: GetStatement method 💊

### DIFF
--- a/lib/payme/serializers.py
+++ b/lib/payme/serializers.py
@@ -15,10 +15,14 @@ class MerchatTransactionsModelSerializer(serializers.ModelSerializer):
     MerchatTransactionsModelSerializer class \
         That's used to serialize merchat transactions data.
     """
+    start_date = serializers.IntegerField(allow_null=True)
+    end_date = serializers.IntegerField(allow_null=True)
+
     class Meta:
         # pylint: disable=missing-class-docstring
         model: MerchatTransactionsModel = MerchatTransactionsModel
         fields: str = "__all__"
+        extra_fields = ['start_date', 'end_date']
 
     def validate(self, attrs) -> dict:
         """

--- a/lib/payme/utils/get_params.py
+++ b/lib/payme/utils/get_params.py
@@ -12,8 +12,10 @@ def get_params(params: dict) -> dict:
     clean_params["time"] = params.get("time")
     clean_params["amount"] = params.get("amount")
     clean_params["reason"] = params.get("reason")
-    clean_params["from"] = params.get("from")
-    clean_params["to"] = params.get("to")
+    
+    # get statement method params
+    clean_params["start_date"] = params.get("from")
+    clean_params["end_date"] = params.get("to")
 
     if account is not None:
         account_name: str = settings.PAYME.get("PAYME_ACCOUNT")

--- a/lib/payme/utils/make_aware_datetime.py
+++ b/lib/payme/utils/make_aware_datetime.py
@@ -1,0 +1,21 @@
+from django.utils.timezone import datetime as dt
+from django.utils.timezone import make_aware
+
+
+def make_aware_datetime(start_date: int, end_date: int):
+    """
+    Convert Unix timestamps to aware datetimes.
+
+    :param start_date: Unix timestamp (milliseconds)
+    :param end_date: Unix timestamp (milliseconds)
+
+    :return: A tuple of two aware datetimes
+    """
+    return map(
+        lambda timestamp: make_aware(
+            dt.fromtimestamp(
+                timestamp / 1000
+            )
+        ),
+        [start_date, end_date]
+    )


### PR DESCRIPTION
- fixed: `TypeError: Object of type coroutine is not JSON serializable`

- removed: `async` keyword from `__call__` method

- added: two additional (non model) fields in ModelSerializer

- changed: `_from` and `_to` to `start_date` and `end_date` to avoid conflicts due to the Python `from` keyword

- added: new utility to [make aware naive datetimes](https://docs.djangoproject.com/en/dev/topics/i18n/timezones/#naive-and-aware-datetime-objects)