### PR TITLE
feat: add pypi project description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+here = pathlib.Path(__file__).parent.resolve()
+
+long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name='payme-pkg',
@@ -15,4 +18,6 @@ setup(
         "dataclasses==0.*;python_version<'3.7'",  # will only install on py3.6
         'djangorestframework==3.*'
       ],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
This pull request updates setup.py to display the contents of README.md as the long description on the PyPI page for payme-pkg. Currently, the PyPI page lacks a detailed description, which can make it harder for users to understand the functionality and benefits of the package directly from PyPI.